### PR TITLE
[DR-00] docs: add local REST API docs

### DIFF
--- a/be/douren-backend/README.md
+++ b/be/douren-backend/README.md
@@ -3,6 +3,16 @@ npm install
 npm run dev
 ```
 
+API docs (local):
+
+```
+# OpenAPI JSON
+http://localhost:2000/openapi.json
+
+# Swagger UI
+http://localhost:2000/docs
+```
+
 ```
 npm run deploy
 ```

--- a/be/douren-backend/package.json
+++ b/be/douren-backend/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@hono/trpc-server": "^0.3.2",
-    "@hono/zod-validator": "^0.4.1",
+    "@hono/swagger-ui": "^0.5.3",
+    "@hono/zod-openapi": "^1.2.0",
     "@pkg/database": "workspace:*",
     "@pkg/type": "workspace:*",
     "@trpc/server": "11.0.0-rc.553",

--- a/be/douren-backend/src/routes/artist.ts
+++ b/be/douren-backend/src/routes/artist.ts
@@ -1,17 +1,16 @@
-import { Hono } from "hono";
-import { zValidator } from "@hono/zod-validator";
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import {
 	CreateArtistSchema,
-	CreateArtistSchemaTypes,
 	DeleteAristSchema,
 	GetArtistByIdSchema,
 	UpdateArtistSchema,
 } from "@/schema/artist.zod";
 import { authProcedure, publicProcedure, router } from "@/lib/trpc";
-import { artistInputParams } from "@pkg/type";
+import { artistInputParams, artistSchema } from "@pkg/type";
 import { NewArtistDao } from "@/Dao/Artist";
 import { zodSchema, zodSchemaType } from "@pkg/database/zod";
 import { HonoEnv } from "@/index";
+import { z } from "zod";
 
 export const trpcArtistRoute = router({
 	getArtist: publicProcedure.input(artistInputParams).query(async (opts) => {
@@ -50,49 +49,138 @@ export const trpcArtistRoute = router({
 		}),
 });
 
-const ArtistRoute = new Hono<HonoEnv>()
-	.get("/", zValidator("query", artistInputParams), async (c) => {
+const listArtistRoute = createRoute({
+	method: "get",
+	path: "/",
+	tags: ["Artist"],
+	request: {
+		query: artistInputParams,
+	},
+	responses: {
+		200: {
+			description: "Paginated artist list",
+			content: { "application/json": { schema: artistSchema } },
+		},
+	},
+});
+
+const getArtistByIdRoute = createRoute({
+	method: "get",
+	path: "/{artistId}",
+	tags: ["Artist"],
+	request: {
+		params: z.object({ artistId: z.string() }),
+	},
+	responses: {
+		200: {
+			description: "Artist by ID",
+			content: {
+				"application/json": {
+					schema: zodSchema.authorMain.SelectSchema.nullable(),
+				},
+			},
+		},
+	},
+});
+
+const createArtistRoute = createRoute({
+	method: "post",
+	path: "/",
+	tags: ["Artist"],
+	request: {
+		body: {
+			content: {
+				"application/json": { schema: CreateArtistSchema },
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "Create artist",
+			content: {
+				"application/json": {
+					schema: z.array(zodSchema.authorMain.SelectSchema),
+				},
+			},
+		},
+	},
+});
+
+const deleteArtistRoute = createRoute({
+	method: "delete",
+	path: "/{artistId}",
+	tags: ["Artist"],
+	request: {
+		params: z.object({ artistId: z.string() }),
+	},
+	responses: {
+		200: {
+			description: "Delete artist",
+			content: {
+				"application/json": {
+					schema: z.array(zodSchema.authorMain.SelectSchema),
+				},
+			},
+		},
+	},
+});
+
+const updateArtistRoute = createRoute({
+	method: "put",
+	path: "/{artistId}",
+	tags: ["Artist"],
+	request: {
+		params: z.object({ artistId: z.string() }),
+		body: {
+			content: {
+				"application/json": { schema: zodSchema.authorMain.InsertSchema },
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "Update artist",
+			content: {
+				"application/json": {
+					schema: z.array(zodSchema.authorMain.SelectSchema),
+				},
+			},
+		},
+	},
+});
+
+const ArtistRoute = new OpenAPIHono<HonoEnv>()
+	.openapi(listArtistRoute, async (c) => {
 		const ArtistDao = NewArtistDao(c.var.db);
-		const { page, search, tag, sort, searchTable } = c.req.query();
-		const returnObj = await ArtistDao.Fetch({
-			page,
-			search,
-			tag,
-			sort,
-			searchTable,
-		});
+		const query = c.req.valid("query");
+		const returnObj = await ArtistDao.Fetch(query);
 		return c.json(returnObj);
 	})
-	.get("/:artistId", async (c) => {
+	.openapi(getArtistByIdRoute, async (c) => {
 		const ArtistDao = NewArtistDao(c.var.db);
-		const { artistId } = c.req.param();
+		const { artistId } = c.req.valid("param");
 		const returnObj = await ArtistDao.FetchById(artistId);
-		return c.json(returnObj);
+		return c.json(returnObj ?? null);
 	})
-	.post("/", zValidator("json", CreateArtistSchema), async (c) => {
+	.openapi(createArtistRoute, async (c) => {
 		const ArtistDao = NewArtistDao(c.var.db);
-		const body: CreateArtistSchemaTypes = await c.req.json();
+		const body = c.req.valid("json");
 		const returnResponse = await ArtistDao.Create(body);
 		return c.json(returnResponse, 200);
 	})
-	.delete("/:artistId", async (c) => {
+	.openapi(deleteArtistRoute, async (c) => {
 		const ArtistDao = NewArtistDao(c.var.db);
-		const { artistId } = c.req.param();
-		const returnResponse = ArtistDao.Delete(artistId);
+		const { artistId } = c.req.valid("param");
+		const returnResponse = await ArtistDao.Delete(artistId);
 		return c.json(returnResponse, 200);
 	})
-	.put(
-		"/:artistId",
-		zValidator("json", zodSchema.authorMain.InsertSchema),
-		async (c) => {
-			const ArtistDao = NewArtistDao(c.var.db);
-			const { artistId } = c.req.param();
-			const body: zodSchemaType["authorMain"]["InsertSchema"] =
-				await c.req.json();
-			const returnResponse = await ArtistDao.Update(artistId, body);
-
-			return c.json(returnResponse, 200);
-		},
-	);
+	.openapi(updateArtistRoute, async (c) => {
+		const ArtistDao = NewArtistDao(c.var.db);
+		const { artistId } = c.req.valid("param");
+		const body: zodSchemaType["authorMain"]["InsertSchema"] =
+			c.req.valid("json");
+		const returnResponse = await ArtistDao.Update(artistId, body);
+		return c.json(returnResponse, 200);
+	});
 
 export default ArtistRoute;

--- a/be/douren-backend/src/routes/owner.ts
+++ b/be/douren-backend/src/routes/owner.ts
@@ -1,7 +1,9 @@
-import { Hono } from "hono";
 import { publicProcedure, router } from "@/lib/trpc";
 import { NewOwnerDao } from "@/Dao/Owner";
 import { HonoEnv } from "@/index";
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { zodSchema } from "@pkg/database/zod";
+import { z } from "zod";
 
 export const trpcOwnerRoute = router({
 	getOwner: publicProcedure.query(async (opts) => {
@@ -10,10 +12,27 @@ export const trpcOwnerRoute = router({
 	}),
 });
 
-const OwnerRoute = new Hono<HonoEnv>().get("/", async (c) => {
-	const OwnerDao = NewOwnerDao(c.var.db);
-	const data = await OwnerDao.Fetch();
-	return c.json(data);
+const getOwnerRoute = createRoute({
+	method: "get",
+	path: "/",
+	tags: ["Owner"],
+	responses: {
+		200: {
+			description: "List owners",
+			content: {
+				"application/json": { schema: z.array(zodSchema.owner.SelectSchema) },
+			},
+		},
+	},
 });
+
+const OwnerRoute = new OpenAPIHono<HonoEnv>().openapi(
+	getOwnerRoute,
+	async (c) => {
+		const OwnerDao = NewOwnerDao(c.var.db);
+		const data = await OwnerDao.Fetch();
+		return c.json(data);
+	},
+);
 
 export default OwnerRoute;

--- a/be/douren-backend/src/routes/tag.ts
+++ b/be/douren-backend/src/routes/tag.ts
@@ -1,7 +1,9 @@
 import { publicProcedure, router } from "@/lib/trpc";
-import { Hono } from "hono";
+import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { fetchTag } from "@/Dao/Tag";
 import { HonoEnv } from "@/index";
+import { zodSchema } from "@pkg/database/zod";
+import { z } from "zod";
 
 export const trpcTagRoute = router({
 	getTag: publicProcedure.query(async (opts) => {
@@ -11,7 +13,24 @@ export const trpcTagRoute = router({
 	}),
 });
 
-export const TagRoute = new Hono<HonoEnv>().get("/", async (c) => {
-	const data = fetchTag(c.var.db);
-	return c.json(data);
+const getTagRoute = createRoute({
+	method: "get",
+	path: "/",
+	tags: ["Tag"],
+	responses: {
+		200: {
+			description: "List tags",
+			content: {
+				"application/json": { schema: z.array(zodSchema.tag.SelectSchema) },
+			},
+		},
+	},
 });
+
+export const TagRoute = new OpenAPIHono<HonoEnv>().openapi(
+	getTagRoute,
+	async (c) => {
+		const data = await fetchTag(c.var.db);
+		return c.json(data);
+	},
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,12 +56,15 @@ importers:
 
   be/douren-backend:
     dependencies:
+      '@hono/swagger-ui':
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.11.4)
       '@hono/trpc-server':
         specifier: ^0.3.2
         version: 0.3.4(@trpc/server@11.0.0-rc.553)(hono@4.11.4)
-      '@hono/zod-validator':
-        specifier: ^0.4.1
-        version: 0.4.3(hono@4.11.4)(zod@4.3.5)
+      '@hono/zod-openapi':
+        specifier: ^1.2.0
+        version: 1.2.0(hono@4.11.4)(zod@4.3.5)
       '@pkg/database':
         specifier: workspace:*
         version: link:../../pkg/database
@@ -321,7 +324,7 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0))
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -376,7 +379,7 @@ importers:
         version: 3.3.3
       tailwindcss:
         specifier: ^3.4.14
-        version: 3.4.19(tsx@4.21.0)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       typescript:
         specifier: ^5.5.3
         version: 5.9.3
@@ -554,7 +557,7 @@ importers:
         version: 36.0.1(stylelint@16.26.1(typescript@5.9.3))
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
@@ -667,6 +670,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@asteasolutions/zod-to-openapi@8.4.0':
+    resolution: {integrity: sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -2046,6 +2054,11 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@hono/swagger-ui@0.5.3':
+    resolution: {integrity: sha512-Hn90DOOJ62ICJQplQvCDVpi9Jcn6EhtRaiffyJIS53wA5RmRLtMCDQGVc0bor8vQD7JIwpkweWjs+3cycp+IvA==}
+    peerDependencies:
+      hono: '>=4.0.0'
+
   '@hono/trpc-server@0.3.4':
     resolution: {integrity: sha512-xFOPjUPnII70FgicDzOJy1ufIoBTu8eF578zGiDOrYOrYN8CJe140s9buzuPkX+SwJRYK8LjEBHywqZtxdm8aA==}
     engines: {node: '>=16.0.0'}
@@ -2053,11 +2066,18 @@ packages:
       '@trpc/server': ^10.10.0 || >11.0.0-rc
       hono: '>=4.*'
 
-  '@hono/zod-validator@0.4.3':
-    resolution: {integrity: sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==}
+  '@hono/zod-openapi@1.2.0':
+    resolution: {integrity: sha512-KDfHqv/Wy4elVseZXgokbHxeWuqBL+AZfqsOMpEihBMUsk/fJ+bLIi3Sf70JFVpt1Ihui8RasYrInozt7ZBDIA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: ^4.0.0
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
       hono: '>=3.9.0'
-      zod: ^3.19.1
+      zod: ^3.25.0 || ^4.0.0
 
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
@@ -5706,6 +5726,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -7020,6 +7043,11 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -7084,6 +7112,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@asteasolutions/zod-to-openapi@8.4.0(zod@4.3.5)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.5
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -8054,12 +8087,24 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@hono/swagger-ui@0.5.3(hono@4.11.4)':
+    dependencies:
+      hono: 4.11.4
+
   '@hono/trpc-server@0.3.4(@trpc/server@11.0.0-rc.553)(hono@4.11.4)':
     dependencies:
       '@trpc/server': 11.0.0-rc.553
       hono: 4.11.4
 
-  '@hono/zod-validator@0.4.3(hono@4.11.4)(zod@4.3.5)':
+  '@hono/zod-openapi@1.2.0(hono@4.11.4)(zod@4.3.5)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 8.4.0(zod@4.3.5)
+      '@hono/zod-validator': 0.7.6(hono@4.11.4)(zod@4.3.5)
+      hono: 4.11.4
+      openapi3-ts: 4.5.0
+      zod: 4.3.5
+
+  '@hono/zod-validator@0.7.6(hono@4.11.4)(zod@4.3.5)':
     dependencies:
       hono: 4.11.4
       zod: 4.3.5
@@ -12072,6 +12117,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -12236,21 +12285,23 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
       tsx: 4.21.0
+      yaml: 2.8.2
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.21.0
+      yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -12959,11 +13010,11 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      tailwindcss: 3.4.19(tsx@4.21.0)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
 
-  tailwindcss@3.4.19(tsx@4.21.0):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -12982,7 +13033,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -13084,7 +13135,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -13095,7 +13146,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.55.1
       source-map: 0.7.6
@@ -13538,6 +13589,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.8.2: {}
 
   yargs-parser@21.1.1: {}
 

--- a/steering/standards/api-design-guidelines.md
+++ b/steering/standards/api-design-guidelines.md
@@ -3,6 +3,14 @@
 ## Purpose
 This document establishes patterns and conventions for designing APIs in the Douren system, covering both tRPC procedures and traditional REST endpoints.
 
+## API Documentation (OpenAPI)
+
+REST endpoints should be documented via OpenAPI generated from Zod schemas (so the docs stay in sync with runtime validation).
+
+- Backend dev server exposes the spec at `/openapi.json` and a viewer at `/docs`.
+- When adding/changing REST routes, prefer `OpenAPIHono` + `createRoute` with explicit request/response schemas.
+- Reuse existing Zod schemas from `@pkg/type` (API-level shapes) and `@pkg/database/zod` (table shapes) where possible.
+
 ## tRPC Design Patterns
 
 ### Procedure Naming Conventions


### PR DESCRIPTION
**Summary**
- Serve OpenAPI at `/openapi.json` and Swagger UI at `/docs` in `be/douren-backend`
- Document REST routes (artist/event/tag/owner) via `OpenAPIHono` + Zod schemas
- Add docs pointers in backend README and steering guidelines

**Test plan**
- [x] `pnpm -C be/douren-backend build`
- [x] `pnpm -C be/douren-backend lint`
- [x] `pnpm run devfe` + curl verify `id="root"` for both FE apps (ports auto-selected if busy)
- [ ] `pnpm -C be/douren-backend test` (fails pre-existing: DAO mocks don’t implement `onConflictDoUpdate`)
