### PR TITLE
[DR-00] chore: add line ending config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Normalize line endings for all text files in the repo.
+* text=auto eol=lf
+
+# Keep Windows scripts using CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Treat common binary assets as binary to avoid accidental normalization.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tgz binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.mp4 binary
+*.mov binary


### PR DESCRIPTION
**Summary**
- Add `.gitattributes` to normalize text files to LF
- Add `.editorconfig` so editors default to LF + consistent whitespace

**Test plan**
- [ ] `git diff origin/main...HEAD` shows only these 2 files
