### PR TITLE
[DR-00] ci: remove redundant staging deployment PR comments

### DIFF
--- a/.github/workflows/main-be-stg-deploy.yaml
+++ b/.github/workflows/main-be-stg-deploy.yaml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: read
   deployments: write
-  pull-requests: write
 
 concurrency:
   group: be-preview-${{ github.event.pull_request.number || github.ref }}
@@ -162,44 +161,3 @@ jobs:
               description: "Deployed",
             });
 
-      - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        env:
-          WORKER_NAME: ${{ env.WORKER_NAME }}
-          API_PREVIEW_URL: ${{ env.API_PREVIEW_URL }}
-          PR_SCHEMA: ${{ env.PR_SCHEMA }}
-        with:
-          script: |
-            const marker = "<!-- douren-be-preview -->";
-            const body = `${marker}\nBackend preview deployed.\n`;
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(
-              (c) => c.user?.type === "Bot" && typeof c.body === "string" && c.body.includes(marker),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }

--- a/.github/workflows/main-cms-stg-deploy.yaml
+++ b/.github/workflows/main-cms-stg-deploy.yaml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
   deployments: write
-  pull-requests: write
 
 concurrency:
   group: cms-pages-${{ github.event.pull_request.number || github.ref }}
@@ -157,47 +156,3 @@ jobs:
               description: "Deployed",
             });
 
-      - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
-        uses: actions/github-script@v7
-        env:
-          PAGES_BRANCH: ${{ env.PAGES_BRANCH }}
-          PAGES_PREVIEW_URL: ${{ env.PAGES_PREVIEW_URL }}
-          PAGES_PREVIEW_ALIASES: ${{ env.PAGES_PREVIEW_ALIASES }}
-          API_PREVIEW_URL: ${{ env.API_PREVIEW_URL }}
-          PR_NUMBER: ${{ env.PR_NUMBER || github.event.pull_request.number }}
-        with:
-          script: |
-            const marker = "<!-- douren-cms-preview -->";
-            const previewUrl = process.env.PAGES_PREVIEW_URL || "(no URL returned by wrangler)";
-            const body = `${marker}\nCMS preview is ready:\n${previewUrl}\n`;
-
-            const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER);
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(
-              (c) => c.user?.type === "Bot" && typeof c.body === "string" && c.body.includes(marker),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }

--- a/.github/workflows/main-fe-stg-deploy.yaml
+++ b/.github/workflows/main-fe-stg-deploy.yaml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
   deployments: write
-  pull-requests: write
 
 concurrency:
   group: fe-pages-${{ github.event.pull_request.number || github.ref }}
@@ -159,47 +158,3 @@ jobs:
               description: "Deployed",
             });
 
-      - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
-        uses: actions/github-script@v7
-        env:
-          PAGES_BRANCH: ${{ env.PAGES_BRANCH }}
-          PAGES_PREVIEW_URL: ${{ env.PAGES_PREVIEW_URL }}
-          PAGES_PREVIEW_ALIASES: ${{ env.PAGES_PREVIEW_ALIASES }}
-          API_PREVIEW_URL: ${{ env.API_PREVIEW_URL }}
-          PR_NUMBER: ${{ env.PR_NUMBER || github.event.pull_request.number }}
-        with:
-          script: |
-            const marker = "<!-- douren-fe-preview -->";
-            const previewUrl = process.env.PAGES_PREVIEW_URL || "(no URL returned by wrangler)";
-            const body = `${marker}\nFrontend preview is ready:\n${previewUrl}\n`;
-
-            const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER);
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            const existing = comments.find(
-              (c) => c.user?.type === "Bot" && typeof c.body === "string" && c.body.includes(marker),
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }


### PR DESCRIPTION
## Summary
- Remove "Comment PR with preview URL" steps from all three staging deployment workflows
- Remove `pull-requests: write` permission (no longer needed after removing comment steps)

The preview URLs are still accessible via the GitHub Deployments UI on the PR page, making the comment redundant.

## Test plan
- [ ] Verify staging deployments still work without errors
- [ ] Verify preview URLs are still visible in PR Deployments section
- [ ] Confirm no more bot comments are posted on staging deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)