### PR TITLE
[DR-00] refactor: centralize auth guards

### DIFF
--- a/be/douren-backend/src/__tests__/lib/auth-guards.test.ts
+++ b/be/douren-backend/src/__tests__/lib/auth-guards.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import type { HonoVariables } from "@/index";
+import {
+	assertAuthenticatedSession,
+	UNAUTHORIZED_MESSAGE,
+} from "@/lib/auth/guards";
+
+describe("auth guards", () => {
+	it("throws UNAUTHORIZED when user is missing", () => {
+		const ctx: Pick<HonoVariables, "user" | "session"> = {
+			user: null,
+			session: null,
+		};
+
+		expect(() => assertAuthenticatedSession(ctx)).toThrowError(TRPCError);
+		expect(() => assertAuthenticatedSession(ctx)).toThrowError(
+			UNAUTHORIZED_MESSAGE,
+		);
+	});
+
+	it("returns user and session when present", () => {
+		const ctx: Pick<HonoVariables, "user" | "session"> = {
+			user: { id: "user-1" } as NonNullable<HonoVariables["user"]>,
+			session: { id: "session-1" } as NonNullable<HonoVariables["session"]>,
+		};
+
+		const result = assertAuthenticatedSession(ctx);
+		expect(result.user).toBe(ctx.user);
+		expect(result.session).toBe(ctx.session);
+	});
+});

--- a/be/douren-backend/src/__tests__/lib/authorization-guards.test.ts
+++ b/be/douren-backend/src/__tests__/lib/authorization-guards.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import { s } from "@pkg/database/db";
+import type { HonoVariables } from "@/index";
+import * as authorization from "@/lib/authorization";
+
+type DbMock = Pick<HonoVariables["db"], "select">;
+
+type DbMockOptions = {
+	roleName: string | null;
+	artistUserId: string | null;
+};
+
+const createDbMock = ({ roleName, artistUserId }: DbMockOptions): DbMock => {
+	return {
+		select: vi.fn(() => ({
+			from: vi.fn((table: unknown) => ({
+				where: vi.fn(() => ({
+					limit: vi.fn(async () => {
+						if (table === s.userRole) {
+							return roleName ? [{ name: roleName }] : [];
+						}
+						if (table === s.authorMain) {
+							return [{ userId: artistUserId }];
+						}
+						return [];
+					}),
+				})),
+			})),
+		})),
+	};
+};
+
+describe("authorization guards", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		authorization.clearAllRoleCaches();
+	});
+
+	it("assertCanEditArtist throws FORBIDDEN when unauthorized", async () => {
+		const db = createDbMock({
+			roleName: "user",
+			artistUserId: "someone-else",
+		}) as HonoVariables["db"];
+
+		await expect(
+			authorization.assertCanEditArtist(db, "user-1", 123),
+		).rejects.toBeInstanceOf(TRPCError);
+		await expect(
+			authorization.assertCanEditArtist(db, "user-1", 123),
+		).rejects.toThrow(authorization.ARTIST_FORBIDDEN_MESSAGES.edit);
+	});
+
+	it("assertCanDeleteArtist throws FORBIDDEN when unauthorized", async () => {
+		const db = createDbMock({
+			roleName: "user",
+			artistUserId: "someone-else",
+		}) as HonoVariables["db"];
+
+		await expect(
+			authorization.assertCanDeleteArtist(db, "user-1", 456),
+		).rejects.toBeInstanceOf(TRPCError);
+		await expect(
+			authorization.assertCanDeleteArtist(db, "user-1", 456),
+		).rejects.toThrow(authorization.ARTIST_FORBIDDEN_MESSAGES.delete);
+	});
+
+	it("assertCanEditArtist does not throw when authorized", async () => {
+		const db = createDbMock({
+			roleName: "admin",
+			artistUserId: "someone-else",
+		}) as HonoVariables["db"];
+
+		await expect(
+			authorization.assertCanEditArtist(db, "user-1", 789),
+		).resolves.toBeUndefined();
+	});
+});

--- a/be/douren-backend/src/index.ts
+++ b/be/douren-backend/src/index.ts
@@ -21,6 +21,7 @@ import { cache } from "hono/cache";
 import { auth, type Auth, AuthSession } from "@/lib/auth";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
+import { requireAuthenticatedUser } from "@/lib/auth/guards";
 
 export type HonoVariables = {
 	db: ReturnType<typeof initDB>;
@@ -102,13 +103,8 @@ const sessionAuthMiddleware = async (
 	c: Context<HonoEnv>,
 	next: () => Promise<void>,
 ) => {
-	const user = c.get("user");
-	if (!user) {
-		return c.json(
-			{ message: "You must be logged in to access this resource" },
-			401,
-		);
-	}
+	const userOrResponse = requireAuthenticatedUser(c);
+	if (userOrResponse instanceof Response) return userOrResponse;
 	await next();
 };
 

--- a/be/douren-backend/src/lib/auth/guards.ts
+++ b/be/douren-backend/src/lib/auth/guards.ts
@@ -1,0 +1,37 @@
+import { TRPCError } from "@trpc/server";
+import type { Context } from "hono";
+
+import type { HonoEnv, HonoVariables } from "@/index";
+
+export const UNAUTHORIZED_MESSAGE =
+	"You must be logged in to access this resource";
+
+export type AuthenticatedSession = {
+	user: NonNullable<HonoVariables["user"]>;
+	session: NonNullable<HonoVariables["session"]>;
+};
+
+export function assertAuthenticatedSession(
+	ctx: Pick<HonoVariables, "user" | "session">,
+): AuthenticatedSession {
+	const { user, session } = ctx;
+	if (!user || !session) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: UNAUTHORIZED_MESSAGE,
+		});
+	}
+	return { user, session };
+}
+
+export function respondUnauthorized(c: Context<HonoEnv>): Response {
+	return c.json({ message: UNAUTHORIZED_MESSAGE }, 401);
+}
+
+export function requireAuthenticatedUser(
+	c: Context<HonoEnv>,
+): NonNullable<HonoVariables["user"]> | Response {
+	const user = c.get("user");
+	if (!user) return respondUnauthorized(c);
+	return user;
+}

--- a/be/douren-backend/src/lib/authorization.ts
+++ b/be/douren-backend/src/lib/authorization.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
 import { s } from "@pkg/database/db";
 import type { HonoVariables } from "@/index";
 import { LRUCache } from "lru-cache";
@@ -83,6 +84,40 @@ export async function canDeleteArtist(
 ): Promise<boolean> {
 	return canEditArtist(db, userId, artistId);
 }
+
+export const ARTIST_FORBIDDEN_MESSAGES = {
+	edit: "You don't have permission to edit this artist",
+	delete: "You don't have permission to delete this artist",
+} as const;
+
+export async function assertCanEditArtist(
+	db: DrizzleDB,
+	userId: string,
+	artistId: number,
+): Promise<void> {
+	const authorized = await canEditArtist(db, userId, artistId);
+	if (!authorized) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: ARTIST_FORBIDDEN_MESSAGES.edit,
+		});
+	}
+}
+
+export async function assertCanDeleteArtist(
+	db: DrizzleDB,
+	userId: string,
+	artistId: number,
+): Promise<void> {
+	const authorized = await canDeleteArtist(db, userId, artistId);
+	if (!authorized) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: ARTIST_FORBIDDEN_MESSAGES.delete,
+		});
+	}
+}
+
 
 /**
  * Clears the role cache for a specific user

--- a/be/douren-backend/src/lib/trpc.ts
+++ b/be/douren-backend/src/lib/trpc.ts
@@ -3,6 +3,7 @@ import { ENV_BINDING } from "@pkg/env/constant";
 import { HonoVariables } from "@/index";
 import { Context } from "hono";
 import { isAdmin } from "@/lib/authorization";
+import { assertAuthenticatedSession } from "@/lib/auth/guards";
 
 type HonoContext = {
 	env: ENV_BINDING;
@@ -21,14 +22,7 @@ type AuthContext = HonoContext & {
 
 export const authProcedure: ReturnType<typeof t.procedure.use<AuthContext>> =
 	t.procedure.use(async (opts) => {
-		const user = opts.ctx.user;
-		const session = opts.ctx.session;
-		if (!user || !session) {
-			throw new TRPCError({
-				code: "UNAUTHORIZED",
-				message: "You must be logged in to access this resource",
-			});
-		}
+		const { user, session } = assertAuthenticatedSession(opts.ctx);
 		return opts.next({
 			ctx: {
 				...opts.ctx,


### PR DESCRIPTION
## Summary
- centralize auth guard helpers for tRPC and REST
- consolidate artist permission error messages
- add guard unit tests for auth/authz

## Test plan
- [x] npm run build
- [x] npm run test
- [x] npm run dev (Douren-frontend: OK, CMS: OK)