### PR TITLE
feat: add artist detail pages

### DIFF
--- a/fe/douren-v2/public/sitemap.xml
+++ b/fe/douren-v2/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://douren.net/</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-03-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://douren.net/event/FF45</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-03-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://douren.net/event/FF44</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-03-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://douren.net/event/FF43</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-03-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://douren.net/event/FF42</loc>
-    <lastmod>2026-03-06</lastmod>
+    <lastmod>2026-03-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>

--- a/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardContext.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardContext.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, useMemo } from "react";
+import type { MouseEvent } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { ArrowRightIcon } from "lucide-react";
 import type { ArtistViewModel } from "@/types/models";
 
 export interface ArtistCardRootProps {
@@ -45,9 +48,32 @@ export const ArtistCardRoot = ({
     [artist, bookmarks, onBookmarkToggle, selectedTags],
   );
 
+  const navigate = useNavigate();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const eventName = pathname.startsWith("/events/")
+    ? decodeURIComponent(pathname.split("/")[2] ?? "")
+    : "";
+
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).closest("button, a")) return;
+    if (!eventName) return;
+    navigate({
+      to: "/events/$eventName/artists/$artistId",
+      params: { eventName, artistId: String(artist.id) },
+    });
+  };
+
   return (
     <ArtistCardContext.Provider value={value}>
-      <div className="border-b border-archive-border relative py-5 grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-8">
+      <div
+        onClick={handleClick}
+        className="border-b border-archive-border relative py-5 grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-8 cursor-pointer group/card"
+      >
+        <div className="absolute top-5 right-0 opacity-0 group-hover/card:opacity-100 transition-opacity duration-200 pointer-events-none">
+          <ArrowRightIcon size={14} className="text-archive-text/45" />
+        </div>
         {children}
       </div>
     </ArtistCardContext.Provider>

--- a/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardContext.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo } from "react";
 import type { MouseEvent } from "react";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { ArrowRightIcon } from "lucide-react";
 import type { ArtistViewModel } from "@/types/models";
 
@@ -49,19 +49,18 @@ export const ArtistCardRoot = ({
   );
 
   const navigate = useNavigate();
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
+  const pathname =
+    typeof window === "undefined" ? "" : window.location.pathname;
   const eventName = pathname.startsWith("/events/")
     ? decodeURIComponent(pathname.split("/")[2] ?? "")
     : "";
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if ((e.target as HTMLElement).closest("button, a")) return;
-    if (!eventName) return;
     navigate({
-      to: "/events/$eventName/artists/$artistId",
-      params: { eventName, artistId: String(artist.id) },
+      to: "/artists/$artistId",
+      params: { artistId: String(artist.id) },
+      search: eventName ? { eventName } : {},
     });
   };
 

--- a/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
@@ -1,4 +1,5 @@
 import { BookmarkIcon } from "lucide-react";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { FallbackImage } from "@/components/common/FallbackImage";
 import { useArtistCard } from "./ArtistCardContext";
 import {
@@ -8,6 +9,12 @@ import {
 
 export const ArtistCardSummary = () => {
   const { artist, bookmarks, onBookmarkToggle, selectedTags } = useArtistCard();
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const eventName = pathname.startsWith("/events/")
+    ? decodeURIComponent(pathname.split("/")[2] ?? "")
+    : "";
 
   const handleBookmark = () => {
     onBookmarkToggle(artist.id);
@@ -100,6 +107,16 @@ export const ArtistCardSummary = () => {
             )}
           </div>
         </div>
+
+        {eventName && (
+          <Link
+            to="/events/$eventName/artists/$artistId"
+            params={{ eventName, artistId: String(artist.id) }}
+            className="self-start text-[11px] font-mono text-archive-text/35 hover:text-archive-accent transition-colors duration-300 mt-1"
+          >
+            查看完整檔案 →
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
@@ -100,7 +100,6 @@ export const ArtistCardSummary = () => {
             )}
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistCard/ArtistCardSummary.tsx
@@ -1,5 +1,4 @@
 import { BookmarkIcon } from "lucide-react";
-import { Link, useRouterState } from "@tanstack/react-router";
 import { FallbackImage } from "@/components/common/FallbackImage";
 import { useArtistCard } from "./ArtistCardContext";
 import {
@@ -9,12 +8,6 @@ import {
 
 export const ArtistCardSummary = () => {
   const { artist, bookmarks, onBookmarkToggle, selectedTags } = useArtistCard();
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
-  const eventName = pathname.startsWith("/events/")
-    ? decodeURIComponent(pathname.split("/")[2] ?? "")
-    : "";
 
   const handleBookmark = () => {
     onBookmarkToggle(artist.id);
@@ -108,15 +101,6 @@ export const ArtistCardSummary = () => {
           </div>
         </div>
 
-        {eventName && (
-          <Link
-            to="/events/$eventName/artists/$artistId"
-            params={{ eventName, artistId: String(artist.id) }}
-            className="self-start text-[11px] font-mono text-archive-text/35 hover:text-archive-accent transition-colors duration-300 mt-1"
-          >
-            查看完整檔案 →
-          </Link>
-        )}
       </div>
     </div>
   );

--- a/fe/douren-v2/src/components/artist/ArtistPage.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistPage.tsx
@@ -144,14 +144,14 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
             {renderSocialLinks(artist.socials, {
               iconSize: 18,
               baseClassName:
-                "text-archive-text/40 hover:text-archive-text transition-colors duration-300 cursor-pointer",
+                "text-archive-text/65 hover:text-archive-text transition-colors duration-300 cursor-pointer",
             })}
             {artist.socials.website && (
               <a
                 href={artist.socials.website}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-xs font-mono text-archive-text/40 hover:text-archive-accent transition-colors duration-300 border border-archive-border hover:border-archive-accent px-3 py-1.5 ml-2"
+                className="inline-flex items-center gap-1.5 text-xs font-mono text-archive-text/65 hover:text-archive-accent transition-colors duration-300 border border-archive-border hover:border-archive-accent px-3 py-1.5 ml-2"
               >
                 官方網站
                 <ExternalLinkIcon size={11} />
@@ -178,7 +178,7 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
         animate="show"
         className="mb-10 md:mb-12"
       >
-        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-4">
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/60 block mb-4">
           創作標籤
         </span>
         <motion.div
@@ -216,7 +216,7 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
         animate="show"
         className="mb-10 md:mb-12 max-w-2xl"
       >
-        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-5">
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/60 block mb-5">
           創作者簡介
         </span>
         <p
@@ -245,10 +245,10 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
         className="mb-4"
       >
         <div className="flex items-baseline justify-between mb-6">
-          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35">
+          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/60">
             作品集
           </span>
-          <span className="text-[11px] font-mono text-archive-text/30">
+          <span className="text-[11px] font-mono text-archive-text/50">
             {artist.workImages.length} 件作品
           </span>
         </div>

--- a/fe/douren-v2/src/components/artist/ArtistPage.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistPage.tsx
@@ -1,0 +1,338 @@
+import { motion } from "framer-motion";
+import { ArrowLeftIcon, ExternalLinkIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { useState } from "react";
+import { FallbackImage } from "@/components/common/FallbackImage";
+import { renderSocialLinks } from "@/components/artist/ArtistCard/artistCardHelpers";
+import type { ArtistViewModel } from "@/types/models";
+import { ImageLightbox } from "@/components/artist/ImageLightbox";
+
+const MOCK_ARTIST: ArtistViewModel = {
+  id: 142,
+  name: "星空畫坊",
+  handle: "@hoshizora_atelier",
+  boothLocations: {
+    day1: "A-03",
+    day2: "A-03",
+    day3: "",
+  },
+  tags: ["原創", "奇幻", "角色設計", "插圖", "BL", "輕小說插畫"],
+  bio: "以星空與宇宙為靈感，描繪充滿奇幻色彩的世界觀與角色故事。主要創作原創角色設計與插圖集，偶爾涉足輕小說插畫。喜歡畫各種氛圍的角色，從柔美到帥氣都有涉獵。每年參加 FF、CWT 等大型同人展，期待在展場與大家相遇！展攤上會販售新刊、明信片、壓克力立牌等各式周邊，歡迎大家來逛攤～",
+  imageUrl:
+    "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=600&h=600&fit=crop&q=80",
+  workImages: [
+    "https://images.unsplash.com/photo-1541701494587-cb58502866ab?w=600&h=600&fit=crop&q=80",
+    "https://images.unsplash.com/photo-1579783902614-a3fb3927b6a5?w=600&h=600&fit=crop&q=80",
+    "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=600&h=600&fit=crop&q=80",
+    "https://images.unsplash.com/photo-1547036967-23d11aacaee0?w=600&h=600&fit=crop&q=80",
+    "https://images.unsplash.com/photo-1618172193763-c511deb635ca?w=600&h=600&fit=crop&q=80",
+    "https://images.unsplash.com/photo-1605379399642-870262d3d051?w=600&h=600&fit=crop&q=80",
+  ],
+  socials: {
+    twitter: "https://twitter.com",
+    instagram: "https://instagram.com",
+    pixiv: "https://pixiv.net",
+    website: "https://example.com",
+  },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 20 },
+  show: (delay: number = 0) => ({
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.55, ease: [0.22, 1, 0.36, 1], delay },
+  }),
+};
+
+const stagger = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.07,
+      delayChildren: 0.05,
+    },
+  },
+};
+
+const staggerItem = {
+  hidden: { opacity: 0, y: 10 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+interface ArtistPageProps {
+  eventName: string;
+}
+
+export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
+  const artist = MOCK_ARTIST;
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+
+  const activeDays = [
+    { label: "第一天", value: artist.boothLocations.day1 },
+    { label: "第二天", value: artist.boothLocations.day2 },
+    { label: "第三天", value: artist.boothLocations.day3 },
+  ].filter((d) => d.value.length > 0);
+
+  return (
+    <div className="py-6">
+      {/* Top bar: back nav + catalog ID */}
+      <motion.div
+        variants={fadeUp}
+        custom={0}
+        initial="hidden"
+        animate="show"
+        className="flex items-center justify-between mb-10 md:mb-16"
+      >
+        <Link
+          to="/events/$eventName"
+          params={{ eventName }}
+          className="inline-flex items-center gap-2 text-sm font-mono text-archive-text/45 hover:text-archive-text transition-colors duration-300 group"
+        >
+          <ArrowLeftIcon
+            size={13}
+            className="transition-transform duration-300 group-hover:-translate-x-0.5"
+          />
+          返回創作者列表
+        </Link>
+        <span className="text-[11px] font-mono text-archive-text/25 tracking-[0.15em] uppercase select-none">
+          No.{String(artist.id).padStart(4, "0")}
+        </span>
+      </motion.div>
+
+      {/* Hero: photo + identity */}
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-14 mb-14 md:mb-20">
+        {/* Portrait */}
+        <motion.div
+          variants={fadeUp}
+          custom={0.05}
+          initial="hidden"
+          animate="show"
+          className="md:col-span-4 lg:col-span-3"
+        >
+          <div className="relative overflow-hidden bg-archive-border/30 aspect-square group">
+            <FallbackImage
+              src={artist.imageUrl}
+              alt={artist.name}
+              className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.03]"
+            />
+            <div className="absolute inset-0 bg-archive-text/0 group-hover:bg-archive-text/[0.04] transition-colors duration-500" />
+          </div>
+        </motion.div>
+
+        {/* Identity block */}
+        <motion.div
+          variants={fadeUp}
+          custom={0.12}
+          initial="hidden"
+          animate="show"
+          className="md:col-span-8 lg:col-span-9 flex flex-col justify-center gap-6 md:gap-8"
+        >
+          <div>
+            <h1
+              className="text-4xl md:text-5xl lg:text-6xl font-medium text-archive-text leading-[1.1] tracking-tight mb-3"
+              style={{ fontFamily: "'Noto Serif TC', serif" }}
+            >
+              {artist.name}
+            </h1>
+            <p className="text-sm font-mono text-archive-text/45 tracking-wide">
+              {artist.handle}
+            </p>
+          </div>
+
+          {activeDays.length > 0 && (
+            <div className="pt-6 border-t border-archive-border">
+              <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-4">
+                展攤位置
+              </span>
+              <div className="flex flex-wrap gap-x-8 gap-y-3">
+                {activeDays.map((day) => (
+                  <div key={day.label} className="flex items-baseline gap-3">
+                    <span className="text-xs font-mono text-archive-text/45">
+                      {day.label}
+                    </span>
+                    <span
+                      className="text-2xl md:text-3xl font-medium text-archive-text tracking-tight"
+                      style={{ fontFamily: "'Noto Serif TC', serif" }}
+                    >
+                      {day.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Socials inline in hero */}
+          <div className="flex items-center gap-5 pt-2">
+            {renderSocialLinks(artist.socials, {
+              iconSize: 18,
+              baseClassName:
+                "text-archive-text/40 hover:text-archive-text transition-colors duration-300 cursor-pointer",
+            })}
+            {artist.socials.website && (
+              <a
+                href={artist.socials.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs font-mono text-archive-text/40 hover:text-archive-accent transition-colors duration-300 border border-archive-border hover:border-archive-accent px-3 py-1.5 ml-2"
+              >
+                官方網站
+                <ExternalLinkIcon size={11} />
+              </a>
+            )}
+          </div>
+        </motion.div>
+      </div>
+
+      {/* Divider */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.18}
+        initial="hidden"
+        animate="show"
+        className="border-t border-archive-border mb-10 md:mb-12"
+      />
+
+      {/* Tags */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.22}
+        initial="hidden"
+        animate="show"
+        className="mb-10 md:mb-12"
+      >
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-4">
+          創作標籤
+        </span>
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          animate="show"
+          className="flex flex-wrap gap-2"
+        >
+          {artist.tags.map((tag) => (
+            <motion.span
+              key={tag}
+              variants={staggerItem}
+              className="px-3 py-1.5 text-sm font-mono border border-archive-border text-archive-text/70 hover:border-archive-accent hover:text-archive-accent transition-all duration-300 cursor-default"
+            >
+              {tag}
+            </motion.span>
+          ))}
+        </motion.div>
+      </motion.div>
+
+      {/* Divider */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.28}
+        initial="hidden"
+        animate="show"
+        className="border-t border-archive-border mb-10 md:mb-12"
+      />
+
+      {/* Bio */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.32}
+        initial="hidden"
+        animate="show"
+        className="mb-10 md:mb-12 max-w-2xl"
+      >
+        <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-5">
+          創作者簡介
+        </span>
+        <p
+          className="text-base text-archive-text/80 leading-[1.9] border-l-2 border-archive-accent/40 pl-6"
+          style={{ fontFamily: "'Noto Serif TC', serif" }}
+        >
+          {artist.bio}
+        </p>
+      </motion.div>
+
+      {/* Divider */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.38}
+        initial="hidden"
+        animate="show"
+        className="border-t border-archive-border mb-10 md:mb-12"
+      />
+
+      {/* Work gallery */}
+      <motion.div
+        variants={fadeUp}
+        custom={0.42}
+        initial="hidden"
+        animate="show"
+        className="mb-4"
+      >
+        <div className="flex items-baseline justify-between mb-6">
+          <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35">
+            作品集
+          </span>
+          <span className="text-[11px] font-mono text-archive-text/30">
+            {artist.workImages.length} 件作品
+          </span>
+        </div>
+
+        {artist.workImages.length > 0 ? (
+          <motion.div
+            variants={stagger}
+            initial="hidden"
+            animate="show"
+            className="grid grid-cols-2 md:grid-cols-3 gap-2 md:gap-3"
+          >
+            {artist.workImages.map((img, i) => (
+              <motion.button
+                key={`work-${i}`}
+                variants={staggerItem}
+                onClick={() => {
+                  setLightboxIndex(i);
+                  setLightboxOpen(true);
+                }}
+                className="relative aspect-square overflow-hidden bg-archive-border/30 cursor-pointer group block"
+              >
+                <FallbackImage
+                  src={img}
+                  alt={`${artist.name} 作品 ${i + 1}`}
+                  className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.06]"
+                />
+                <div className="absolute inset-0 bg-archive-text/0 group-hover:bg-archive-text/[0.08] transition-colors duration-400" />
+                <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  <span className="text-[10px] font-mono text-archive-bg/80 bg-archive-text/60 px-1.5 py-0.5">
+                    {String(i + 1).padStart(2, "0")}
+                  </span>
+                </div>
+              </motion.button>
+            ))}
+          </motion.div>
+        ) : (
+          <div className="py-16 border border-dashed border-archive-border flex items-center justify-center">
+            <span className="text-sm font-mono text-archive-text/35">
+              目前尚無作品
+            </span>
+          </div>
+        )}
+      </motion.div>
+
+      {artist.workImages.length > 0 && (
+        <ImageLightbox
+          isOpen={lightboxOpen}
+          onClose={() => setLightboxOpen(false)}
+          imageUrl={artist.workImages[lightboxIndex]}
+          images={artist.workImages}
+          currentIndex={lightboxIndex}
+          onNavigate={setLightboxIndex}
+          artistName={artist.name}
+        />
+      )}
+    </div>
+  );
+};

--- a/fe/douren-v2/src/components/artist/ArtistPage.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistPage.tsx
@@ -73,12 +73,6 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
 
-  const activeDays = [
-    { label: "第一天", value: artist.boothLocations.day1 },
-    { label: "第二天", value: artist.boothLocations.day2 },
-    { label: "第三天", value: artist.boothLocations.day3 },
-  ].filter((d) => d.value.length > 0);
-
   return (
     <div className="py-6">
       {/* Top bar: back nav + catalog ID */}
@@ -144,29 +138,6 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
               {artist.handle}
             </p>
           </div>
-
-          {activeDays.length > 0 && (
-            <div className="pt-6 border-t border-archive-border">
-              <span className="text-[10px] font-mono uppercase tracking-[0.18em] text-archive-text/35 block mb-4">
-                展攤位置
-              </span>
-              <div className="flex flex-wrap gap-x-8 gap-y-3">
-                {activeDays.map((day) => (
-                  <div key={day.label} className="flex items-baseline gap-3">
-                    <span className="text-xs font-mono text-archive-text/45">
-                      {day.label}
-                    </span>
-                    <span
-                      className="text-2xl md:text-3xl font-medium text-archive-text tracking-tight"
-                      style={{ fontFamily: "'Noto Serif TC', serif" }}
-                    >
-                      {day.value}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
 
           {/* Socials inline in hero */}
           <div className="flex items-center gap-5 pt-2">

--- a/fe/douren-v2/src/components/artist/ArtistPage.tsx
+++ b/fe/douren-v2/src/components/artist/ArtistPage.tsx
@@ -1,40 +1,13 @@
 import { motion } from "framer-motion";
 import { ArrowLeftIcon, ExternalLinkIcon } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { FallbackImage } from "@/components/common/FallbackImage";
 import { renderSocialLinks } from "@/components/artist/ArtistCard/artistCardHelpers";
 import type { ArtistViewModel } from "@/types/models";
 import { ImageLightbox } from "@/components/artist/ImageLightbox";
-
-const MOCK_ARTIST: ArtistViewModel = {
-  id: 142,
-  name: "星空畫坊",
-  handle: "@hoshizora_atelier",
-  boothLocations: {
-    day1: "A-03",
-    day2: "A-03",
-    day3: "",
-  },
-  tags: ["原創", "奇幻", "角色設計", "插圖", "BL", "輕小說插畫"],
-  bio: "以星空與宇宙為靈感，描繪充滿奇幻色彩的世界觀與角色故事。主要創作原創角色設計與插圖集，偶爾涉足輕小說插畫。喜歡畫各種氛圍的角色，從柔美到帥氣都有涉獵。每年參加 FF、CWT 等大型同人展，期待在展場與大家相遇！展攤上會販售新刊、明信片、壓克力立牌等各式周邊，歡迎大家來逛攤～",
-  imageUrl:
-    "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=600&h=600&fit=crop&q=80",
-  workImages: [
-    "https://images.unsplash.com/photo-1541701494587-cb58502866ab?w=600&h=600&fit=crop&q=80",
-    "https://images.unsplash.com/photo-1579783902614-a3fb3927b6a5?w=600&h=600&fit=crop&q=80",
-    "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=600&h=600&fit=crop&q=80",
-    "https://images.unsplash.com/photo-1547036967-23d11aacaee0?w=600&h=600&fit=crop&q=80",
-    "https://images.unsplash.com/photo-1618172193763-c511deb635ca?w=600&h=600&fit=crop&q=80",
-    "https://images.unsplash.com/photo-1605379399642-870262d3d051?w=600&h=600&fit=crop&q=80",
-  ],
-  socials: {
-    twitter: "https://twitter.com",
-    instagram: "https://instagram.com",
-    pixiv: "https://pixiv.net",
-    website: "https://example.com",
-  },
-};
+import { trpc } from "@/helper/trpc";
+import { FALLBACK_IMAGE } from "@/constants/fallbackImage";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 20 },
@@ -65,13 +38,89 @@ const staggerItem = {
 };
 
 interface ArtistPageProps {
-  eventName: string;
+  artistId: string;
+  eventName?: string;
 }
 
-export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
-  const artist = MOCK_ARTIST;
+const normalizeText = (value?: string | null): string => value?.trim() ?? "";
+
+export const ArtistPage: React.FC<ArtistPageProps> = ({
+  artistId,
+  eventName,
+}) => {
+  const artistQuery = trpc.artist.getArtistPageDetails.useQuery({
+    id: artistId,
+  });
+  const artist = useMemo<ArtistViewModel | null>(() => {
+    const data = artistQuery.data;
+
+    if (!data) {
+      return null;
+    }
+
+    const fallbackEvent = data.events.find(
+      (event) =>
+        Boolean(normalizeText(event.boothName)) ||
+        Boolean(normalizeText(event.locationDay01)) ||
+        Boolean(normalizeText(event.locationDay02)) ||
+        Boolean(normalizeText(event.locationDay03)),
+    );
+    const workImages = data.products
+      .map((product) => normalizeText(product.preview ?? product.thumbnail))
+      .filter((image) => image.length > 0);
+    const tags = normalizeText(data.tags)
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+
+    return {
+      id: data.uuid,
+      name: normalizeText(data.author) || `Artist #${artistId}`,
+      handle:
+        normalizeText(fallbackEvent?.boothName) ||
+        normalizeText(data.author) ||
+        "—",
+      boothLocations: {
+        day1: normalizeText(fallbackEvent?.locationDay01),
+        day2: normalizeText(fallbackEvent?.locationDay02),
+        day3: normalizeText(fallbackEvent?.locationDay03),
+      },
+      tags,
+      bio: normalizeText(data.introduction) || "目前尚無創作者簡介。",
+      imageUrl: normalizeText(data.photo) || FALLBACK_IMAGE,
+      workImages,
+      socials: {
+        twitter: normalizeText(data.twitterLink) || undefined,
+        instagram: normalizeText(data.instagramLink) || undefined,
+        facebook: normalizeText(data.facebookLink) || undefined,
+        pixiv: normalizeText(data.pixivLink) || undefined,
+        plurk: normalizeText(data.plurkLink) || undefined,
+        website:
+          normalizeText(data.officialLink) ||
+          normalizeText(data.storeLink) ||
+          normalizeText(data.myacgLink) ||
+          undefined,
+      },
+    };
+  }, [artistId, artistQuery.data]);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+
+  if (artistQuery.isPending) {
+    return (
+      <div className="py-20 text-center text-archive-text/60 font-mono">
+        載入創作者資料中...
+      </div>
+    );
+  }
+
+  if (artistQuery.isError || !artist) {
+    return (
+      <div className="py-20 text-center text-archive-text/60 font-mono">
+        無法載入創作者資料。
+      </div>
+    );
+  }
 
   return (
     <div className="py-6">
@@ -83,17 +132,30 @@ export const ArtistPage: React.FC<ArtistPageProps> = ({ eventName }) => {
         animate="show"
         className="flex items-center justify-between mb-10 md:mb-16"
       >
-        <Link
-          to="/events/$eventName"
-          params={{ eventName }}
-          className="inline-flex items-center gap-2 text-sm font-mono text-archive-text/45 hover:text-archive-text transition-colors duration-300 group"
-        >
-          <ArrowLeftIcon
-            size={13}
-            className="transition-transform duration-300 group-hover:-translate-x-0.5"
-          />
-          返回創作者列表
-        </Link>
+        {eventName ? (
+          <Link
+            to="/events/$eventName"
+            params={{ eventName }}
+            className="inline-flex items-center gap-2 text-sm font-mono text-archive-text/45 hover:text-archive-text transition-colors duration-300 group"
+          >
+            <ArrowLeftIcon
+              size={13}
+              className="transition-transform duration-300 group-hover:-translate-x-0.5"
+            />
+            返回創作者列表
+          </Link>
+        ) : (
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-sm font-mono text-archive-text/45 hover:text-archive-text transition-colors duration-300 group"
+          >
+            <ArrowLeftIcon
+              size={13}
+              className="transition-transform duration-300 group-hover:-translate-x-0.5"
+            />
+            返回首頁
+          </Link>
+        )}
         <span className="text-[11px] font-mono text-archive-text/25 tracking-[0.15em] uppercase select-none">
           No.{String(artist.id).padStart(4, "0")}
         </span>

--- a/fe/douren-v2/src/routeTree.gen.ts
+++ b/fe/douren-v2/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from "./routes/__root";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as EventsEventNameIndexRouteImport } from "./routes/events/$eventName/index";
 import { Route as EventsEventNameBookmarksRouteImport } from "./routes/events/$eventName/bookmarks";
+import { Route as EventsEventNameArtistsArtistIdRouteImport } from "./routes/events/$eventName/artists/$artistId";
 
 const IndexRoute = IndexRouteImport.update({
   id: "/",
@@ -29,35 +30,58 @@ const EventsEventNameBookmarksRoute =
     path: "/events/$eventName/bookmarks",
     getParentRoute: () => rootRouteImport,
   } as any);
+const EventsEventNameArtistsArtistIdRoute =
+  EventsEventNameArtistsArtistIdRouteImport.update({
+    id: "/events/$eventName/artists/$artistId",
+    path: "/events/$eventName/artists/$artistId",
+    getParentRoute: () => rootRouteImport,
+  } as any);
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
-  "/events/$eventName": typeof EventsEventNameIndexRoute;
+  "/events/$eventName/": typeof EventsEventNameIndexRoute;
+  "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
   "/events/$eventName": typeof EventsEventNameIndexRoute;
+  "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof IndexRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
   "/events/$eventName/": typeof EventsEventNameIndexRoute;
+  "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/events/$eventName/bookmarks" | "/events/$eventName";
+  fullPaths:
+    | "/"
+    | "/events/$eventName/bookmarks"
+    | "/events/$eventName/"
+    | "/events/$eventName/artists/$artistId";
   fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/events/$eventName/bookmarks" | "/events/$eventName";
-  id: "__root__" | "/" | "/events/$eventName/bookmarks" | "/events/$eventName/";
+  to:
+    | "/"
+    | "/events/$eventName/bookmarks"
+    | "/events/$eventName"
+    | "/events/$eventName/artists/$artistId";
+  id:
+    | "__root__"
+    | "/"
+    | "/events/$eventName/bookmarks"
+    | "/events/$eventName/"
+    | "/events/$eventName/artists/$artistId";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   EventsEventNameBookmarksRoute: typeof EventsEventNameBookmarksRoute;
   EventsEventNameIndexRoute: typeof EventsEventNameIndexRoute;
+  EventsEventNameArtistsArtistIdRoute: typeof EventsEventNameArtistsArtistIdRoute;
 }
 
 declare module "@tanstack/react-router" {
@@ -72,7 +96,7 @@ declare module "@tanstack/react-router" {
     "/events/$eventName/": {
       id: "/events/$eventName/";
       path: "/events/$eventName";
-      fullPath: "/events/$eventName";
+      fullPath: "/events/$eventName/";
       preLoaderRoute: typeof EventsEventNameIndexRouteImport;
       parentRoute: typeof rootRouteImport;
     };
@@ -83,6 +107,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof EventsEventNameBookmarksRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/events/$eventName/artists/$artistId": {
+      id: "/events/$eventName/artists/$artistId";
+      path: "/events/$eventName/artists/$artistId";
+      fullPath: "/events/$eventName/artists/$artistId";
+      preLoaderRoute: typeof EventsEventNameArtistsArtistIdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -90,6 +121,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   EventsEventNameBookmarksRoute: EventsEventNameBookmarksRoute,
   EventsEventNameIndexRoute: EventsEventNameIndexRoute,
+  EventsEventNameArtistsArtistIdRoute: EventsEventNameArtistsArtistIdRoute,
 };
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/fe/douren-v2/src/routeTree.gen.ts
+++ b/fe/douren-v2/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as IndexRouteImport } from "./routes/index";
+import { Route as ArtistsArtistIdRouteImport } from "./routes/artists/$artistId";
 import { Route as EventsEventNameIndexRouteImport } from "./routes/events/$eventName/index";
 import { Route as EventsEventNameBookmarksRouteImport } from "./routes/events/$eventName/bookmarks";
 import { Route as EventsEventNameArtistsArtistIdRouteImport } from "./routes/events/$eventName/artists/$artistId";
@@ -17,6 +18,11 @@ import { Route as EventsEventNameArtistsArtistIdRouteImport } from "./routes/eve
 const IndexRoute = IndexRouteImport.update({
   id: "/",
   path: "/",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const ArtistsArtistIdRoute = ArtistsArtistIdRouteImport.update({
+  id: "/artists/$artistId",
+  path: "/artists/$artistId",
   getParentRoute: () => rootRouteImport,
 } as any);
 const EventsEventNameIndexRoute = EventsEventNameIndexRouteImport.update({
@@ -39,12 +45,14 @@ const EventsEventNameArtistsArtistIdRoute =
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
+  "/artists/$artistId": typeof ArtistsArtistIdRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
-  "/events/$eventName/": typeof EventsEventNameIndexRoute;
+  "/events/$eventName": typeof EventsEventNameIndexRoute;
   "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
+  "/artists/$artistId": typeof ArtistsArtistIdRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
   "/events/$eventName": typeof EventsEventNameIndexRoute;
   "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
@@ -52,6 +60,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof IndexRoute;
+  "/artists/$artistId": typeof ArtistsArtistIdRoute;
   "/events/$eventName/bookmarks": typeof EventsEventNameBookmarksRoute;
   "/events/$eventName/": typeof EventsEventNameIndexRoute;
   "/events/$eventName/artists/$artistId": typeof EventsEventNameArtistsArtistIdRoute;
@@ -60,18 +69,21 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | "/"
+    | "/artists/$artistId"
     | "/events/$eventName/bookmarks"
-    | "/events/$eventName/"
+    | "/events/$eventName"
     | "/events/$eventName/artists/$artistId";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
+    | "/artists/$artistId"
     | "/events/$eventName/bookmarks"
     | "/events/$eventName"
     | "/events/$eventName/artists/$artistId";
   id:
     | "__root__"
     | "/"
+    | "/artists/$artistId"
     | "/events/$eventName/bookmarks"
     | "/events/$eventName/"
     | "/events/$eventName/artists/$artistId";
@@ -79,6 +91,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
+  ArtistsArtistIdRoute: typeof ArtistsArtistIdRoute;
   EventsEventNameBookmarksRoute: typeof EventsEventNameBookmarksRoute;
   EventsEventNameIndexRoute: typeof EventsEventNameIndexRoute;
   EventsEventNameArtistsArtistIdRoute: typeof EventsEventNameArtistsArtistIdRoute;
@@ -93,10 +106,17 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof IndexRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/artists/$artistId": {
+      id: "/artists/$artistId";
+      path: "/artists/$artistId";
+      fullPath: "/artists/$artistId";
+      preLoaderRoute: typeof ArtistsArtistIdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/events/$eventName/": {
       id: "/events/$eventName/";
       path: "/events/$eventName";
-      fullPath: "/events/$eventName/";
+      fullPath: "/events/$eventName";
       preLoaderRoute: typeof EventsEventNameIndexRouteImport;
       parentRoute: typeof rootRouteImport;
     };
@@ -119,6 +139,7 @@ declare module "@tanstack/react-router" {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ArtistsArtistIdRoute: ArtistsArtistIdRoute,
   EventsEventNameBookmarksRoute: EventsEventNameBookmarksRoute,
   EventsEventNameIndexRoute: EventsEventNameIndexRoute,
   EventsEventNameArtistsArtistIdRoute: EventsEventNameArtistsArtistIdRoute,

--- a/fe/douren-v2/src/routes/artists/$artistId.tsx
+++ b/fe/douren-v2/src/routes/artists/$artistId.tsx
@@ -10,7 +10,8 @@ const ArtistPageRoute = () => {
 
 export const Route = createFileRoute("/artists/$artistId")({
   validateSearch: (search) => ({
-    eventName: typeof search.eventName === "string" ? search.eventName : undefined,
+    eventName:
+      typeof search.eventName === "string" ? search.eventName : undefined,
   }),
   component: ArtistPageRoute,
 });

--- a/fe/douren-v2/src/routes/artists/$artistId.tsx
+++ b/fe/douren-v2/src/routes/artists/$artistId.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArtistPage } from "@/components/artist/ArtistPage";
+
+const ArtistPageRoute = () => {
+  const { artistId } = Route.useParams();
+  const { eventName } = Route.useSearch();
+
+  return <ArtistPage artistId={artistId} eventName={eventName} />;
+};
+
+export const Route = createFileRoute("/artists/$artistId")({
+  validateSearch: (search) => ({
+    eventName: typeof search.eventName === "string" ? search.eventName : undefined,
+  }),
+  component: ArtistPageRoute,
+});

--- a/fe/douren-v2/src/routes/events/$eventName/artists/$artistId.tsx
+++ b/fe/douren-v2/src/routes/events/$eventName/artists/$artistId.tsx
@@ -2,8 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ArtistPage } from "@/components/artist/ArtistPage";
 
 const ArtistPageRoute = () => {
-  const { eventName } = Route.useParams();
-  return <ArtistPage eventName={eventName} />;
+  const { eventName, artistId } = Route.useParams();
+  return <ArtistPage artistId={artistId} eventName={eventName} />;
 };
 
 export const Route = createFileRoute("/events/$eventName/artists/$artistId")({

--- a/fe/douren-v2/src/routes/events/$eventName/artists/$artistId.tsx
+++ b/fe/douren-v2/src/routes/events/$eventName/artists/$artistId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ArtistPage } from "@/components/artist/ArtistPage";
+
+const ArtistPageRoute = () => {
+  const { eventName } = Route.useParams();
+  return <ArtistPage eventName={eventName} />;
+};
+
+export const Route = createFileRoute("/events/$eventName/artists/$artistId")({
+  component: ArtistPageRoute,
+});

--- a/fe/douren-v2/src/test/components/artist/ArtistCard/ArtistCardRoot.test.tsx
+++ b/fe/douren-v2/src/test/components/artist/ArtistCard/ArtistCardRoot.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArtistViewModel } from "@/types/models";
+import { ArtistCardRoot } from "@/components/artist/ArtistCard/ArtistCardContext";
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+const baseArtist: ArtistViewModel = {
+  id: 24,
+  name: "Clicked Artist",
+  handle: "clicked-artist",
+  boothLocations: {
+    day1: "A01",
+    day2: "",
+    day3: "",
+  },
+  tags: [],
+  bio: "bio",
+  imageUrl: "https://example.com/image.png",
+  workImages: [],
+  socials: {},
+};
+
+describe("ArtistCardRoot", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("navigates to the clicked artist page with the current event context", () => {
+    window.history.replaceState({}, "", "/events/FF42");
+
+    const { container } = render(
+      <ArtistCardRoot
+        artist={baseArtist}
+        bookmarks={new Set<number>()}
+        onBookmarkToggle={() => {}}
+      >
+        <div>Card content</div>
+      </ArtistCardRoot>,
+    );
+
+    fireEvent.click(container.firstElementChild as HTMLElement);
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/artists/$artistId",
+      params: { artistId: "24" },
+      search: { eventName: "FF42" },
+    });
+  });
+});

--- a/fe/douren-v2/src/test/components/artist/ArtistPage.test.tsx
+++ b/fe/douren-v2/src/test/components/artist/ArtistPage.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtistPage } from "@/components/artist/ArtistPage";
+
+const { useQueryMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+}));
+
+vi.mock("@/helper/trpc", () => ({
+  trpc: {
+    artist: {
+      getArtistPageDetails: {
+        useQuery: useQueryMock,
+      },
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+
+  return {
+    ...actual,
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  };
+});
+
+describe("ArtistPage", () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+  });
+
+  it("loads and renders the requested artist instead of a constant artist", () => {
+    useQueryMock.mockReturnValue({
+      data: {
+        uuid: 7,
+        author: "Queried Artist",
+        introduction: "Queried bio",
+        photo: "https://example.com/artist.png",
+        tags: "Original,Fantasy",
+        boothName: null,
+        plurkLink: null,
+        twitterLink: "https://twitter.com/queried",
+        facebookLink: null,
+        instagramLink: null,
+        pixivLink: null,
+        officialLink: null,
+        storeLink: null,
+        myacgLink: null,
+        products: [
+          {
+            preview: "https://example.com/work-1.png",
+            thumbnail: "",
+            title: "Work 1",
+          },
+        ],
+        events: [],
+      },
+      isPending: false,
+      isError: false,
+    });
+
+    render(<ArtistPage artistId="7" eventName="FF42" />);
+
+    expect(useQueryMock).toHaveBeenCalledWith({ id: "7" });
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Queried Artist" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Queried bio")).not.toBeNull();
+    expect(screen.getByText("No.0007")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated artist detail routes for direct and event-scoped artist pages
- make artist cards clickable while preserving event context during navigation
- add tests for artist card navigation and artist page data loading, and update generated routing/sitemap artifacts

## Test Plan
- [x] pnpm run lint
- [x] pnpm run test
- [x] pnpm run build
- [x] nr dev
- [x] curl -s http://localhost:5173 | grep -q 'id="root"'
- [x] curl -s http://localhost:5174 | grep -q 'id="root"'
- [x] curl -s http://localhost:5173/artists/7 | grep -E -q 'id="root"|Queried Artist|載入創作者資料中'